### PR TITLE
Enumerate USB devices on Windows on usb_context initialization

### DIFF
--- a/libyb/usb/detail/win32_usb_context.cpp
+++ b/libyb/usb/detail/win32_usb_context.cpp
@@ -45,6 +45,8 @@ usb_context::~usb_context()
 async_future<void> usb_context::run(std::function<void (usb_plugin_event const &)> const & event_sink)
 {
 	m_pimpl->m_event_sink = event_sink;
+	m_pimpl->refresh_device_list();
+
 	return m_pimpl->m_runner.post(yb::loop([this](cancel_level cl) -> task<void> {
 		return cl >= cl_quit? nulltask: m_pimpl->run_one();
 	}));


### PR DESCRIPTION
Linux implementace tohle dělá, ta na Windows ne.
