### PR TITLE
Accept longer endpoint descriptors in audio interfaces

### DIFF
--- a/libyb/usb/usb_descriptors.cpp
+++ b/libyb/usb/usb_descriptors.cpp
@@ -45,7 +45,7 @@ usb_config_descriptor yb::parse_config_descriptor(yb::buffer_ref d)
 		else if (d[1] == 5/*ENDPOINT*/)
 		{
 			if (!current_altsetting
-				|| desclen != usb_raw_endpoint_descriptor::size)
+				|| desclen < usb_raw_endpoint_descriptor::size)
 			{
 				throw std::runtime_error("invalid descriptor");
 			}


### PR DESCRIPTION
- Interfaces with class == 1 (Audio) have longer endpoint descriptors
  with two extra bytes. Accept them instead of throwing an exception.

Audio USB věci (v mém případě webkamera, Logitech C920) mají evidentně delší deskriptory těch endpointů, vypadá to nějak takhle: http://pastebin.com/acsjZdiy

Tohle je podle libusb, taky tam přijmou buď descriptory o délce 7 nebo 9, nekontrolují jestli ten interface doopravdy je Audio. Ty poslední dva bajty budou neinicializovaný když to není audio interface, hádám že na tom nezáleží (aplikace by k nim neměla přistupovat).
